### PR TITLE
feat: Add log size calculation by index range

### DIFF
--- a/src/braft/log_manager.h
+++ b/src/braft/log_manager.h
@@ -153,6 +153,8 @@ public:
     // Get the internal status of LogManager.
     void get_status(LogManagerStatus* status);
 
+    
+
 private:
 friend class AppendBatcher;
     struct WaitMeta {

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -2256,7 +2256,6 @@ void NodeImpl::on_learner_config_apply(LogEntry *entry) {
 // Returns:
 //   >0: Total size in bytes
 //   -1: If indices are invalid or out of range
-//   -2: If index2 < index1
 // Note: Both indices must be within the valid log range [first_log_index, last_log_index]
 int NodeImpl::get_log_size_diff_by_index(int64_t index1, int64_t index2) {
     if (index1 > index2) {

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -2252,7 +2252,13 @@ void NodeImpl::on_learner_config_apply(LogEntry *entry) {
     }
 }
 
-int NodeImpl::get_log_size_diff_by_index(int index1, int index2) {
+// Calculate the total size of log entries between index1 and index2 (inclusive).
+// Returns:
+//   >0: Total size in bytes
+//   -1: If indices are invalid or out of range
+//   -2: If index2 < index1
+// Note: Both indices must be within the valid log range [first_log_index, last_log_index]
+int NodeImpl::get_log_size_diff_by_index(int64_t index1, int64_t index2) {
     if (index1 > index2) {
         std::swap(index1, index2);
     }
@@ -2261,13 +2267,13 @@ int NodeImpl::get_log_size_diff_by_index(int index1, int index2) {
     const int64_t last_log_index = _log_manager->last_log_index();
 
     if (index1 < first_log_index) {
-        LOG(ERROR) << "node " << _group_id << ":" << _server_id
+        LOG(ERROR) << "node " << _group_id << " : " << _server_id
                    << " index1=" << index1 << " is out of range, first_log_index=" 
                    << first_log_index;
         return -1;
     }
     if (index2 > last_log_index) {
-        LOG(ERROR) << "node " << _group_id << ":" << _server_id
+        LOG(ERROR) << "node " << _group_id << " : " << _server_id
                    << " index2=" << index2 << " is out of range, last_log_index=" 
                    << last_log_index;
         return -1;
@@ -2277,7 +2283,7 @@ int NodeImpl::get_log_size_diff_by_index(int index1, int index2) {
     for (int64_t i = index1; i <= index2; ++i) {
         LogEntry* entry = _log_manager->get_entry(i);
         if (!entry) {
-            LOG(ERROR) << "node " << _group_id << ":" << _server_id
+            LOG(ERROR) << "node " << _group_id << " : " << _server_id
                        << " failed to get log entry at index=" << i;
             return -1;
         }

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -2257,7 +2257,7 @@ void NodeImpl::on_learner_config_apply(LogEntry *entry) {
 //   >0: Total size in bytes
 //   -1: If indices are invalid or out of range
 // Note: Both indices must be within the valid log range [first_log_index, last_log_index]
-int NodeImpl::get_log_size_diff_by_index(int64_t index1, int64_t index2) {
+uint64_t NodeImpl::get_log_size_diff_by_index(int64_t index1, int64_t index2) {
     if (index1 > index2) {
         std::swap(index1, index2);
     }
@@ -2278,7 +2278,7 @@ int NodeImpl::get_log_size_diff_by_index(int64_t index1, int64_t index2) {
         return -1;
     }
 
-    int total_size = 0;
+    uint64_t total_size = 0;
     for (int64_t i = index1; i <= index2; ++i) {
         LogEntry* entry = _log_manager->get_entry(i);
         if (!entry) {

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -20,9 +20,11 @@
 #include <brpc/errno.pb.h>
 #include <brpc/controller.h>
 #include <brpc/channel.h>
+#include <mutex>
 
 #include "braft/errno.pb.h"
 #include "braft/configuration.h"
+#include "braft/macros.h"
 #include "braft/util.h"
 #include "braft/raft.h"
 #include "braft/node.h"
@@ -2262,6 +2264,7 @@ uint64_t NodeImpl::get_log_size_diff_by_index(int64_t index1, int64_t index2) {
         std::swap(index1, index2);
     }
 
+    std::unique_lock<raft_mutex_t> lck_(_mutex);
     const int64_t first_log_index = _log_manager->first_log_index();
     const int64_t last_log_index = _log_manager->last_log_index();
 

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -262,8 +262,13 @@ public:
 
     // Called when the learners configuration is applied to the FSMCaller
     void on_learner_config_apply(LogEntry *entry);
-
-    int get_log_size_diff_by_index(int index1, int index2);
+    
+    // Calculate the total size of log entries between index1 and index2 (inclusive).
+    // Thread-safe.
+    // @param index1 Start index, must be >= first_log_index
+    // @param index2 End index, must be <= last_log_index and >= index1
+    // @return Total size in bytes if successful, negative value on error
+    int get_log_size_diff_by_index(int64_t index1, int64_t index2);
 
 private:
 friend class butil::RefCountedThreadSafe<NodeImpl>;

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -263,6 +263,8 @@ public:
     // Called when the learners configuration is applied to the FSMCaller
     void on_learner_config_apply(LogEntry *entry);
 
+    int get_log_size_diff_by_index(int index1, int index2);
+
 private:
 friend class butil::RefCountedThreadSafe<NodeImpl>;
 

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -268,7 +268,7 @@ public:
     // @param index1 Start index, must be >= first_log_index
     // @param index2 End index, must be <= last_log_index and >= index1
     // @return Total size in bytes if successful, negative value on error
-    int get_log_size_diff_by_index(int64_t index1, int64_t index2);
+    uint64_t get_log_size_diff_by_index(int64_t index1, int64_t index2);
 
 private:
 friend class butil::RefCountedThreadSafe<NodeImpl>;

--- a/src/braft/raft.cpp
+++ b/src/braft/raft.cpp
@@ -272,6 +272,10 @@ bool Node::readonly() {
     return _impl->readonly();
 }
 
+int Node::get_log_size_diff_by_index(int index1, int index2) {
+    return _impl->get_log_size_diff_by_index(index1, index2);
+}
+
 // ------------- Iterator
 void Iterator::next() {
     if (valid()) {

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -817,6 +817,8 @@ public:
     //        is less than the majority.
     bool readonly();
 
+    int get_log_size_diff_by_index(int index1, int index2);
+
 private:
     NodeImpl* _impl;
 };


### PR DESCRIPTION
1. Multiplex the `LogManager::get_entry()` interface to access cached log entries, manage memory/disk consistency, and minimize code changes.
2. Design a `Node::get_log_size_diff_by_index()` interface to calculate the log size difference within a specified index range [index1, index2].

Associated kiwi Issue : https://github.com/arana-db/kiwi/issues/70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a method to calculate log size differences between specified indices.
	- Introduced a virtual first log ID for improved log management.

- **Tests**
	- Added a comprehensive test case for the log size difference calculation method.

These updates enhance log management and tracking capabilities, providing detailed insights into log entry sizes and positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->